### PR TITLE
fix: Current tracing endpoints in how-to on tracing

### DIFF
--- a/docs/how-to/add-tracing-to-cos-lite.md
+++ b/docs/how-to/add-tracing-to-cos-lite.md
@@ -82,10 +82,14 @@ it to `tempo` over the `tracing` relation:
 ```bash 
 $ juju integrate tempo:tracing alertmanager:tracing
 $ juju integrate tempo:tracing catalogue:tracing
-$ juju integrate tempo:tracing grafana:tracing
-$ juju integrate tempo:tracing loki:tracing
-$ juju integrate tempo:tracing prometheus:tracing
-$ juju integrate tempo:tracing traefik:tracing
+$ juju integrate tempo:tracing traefik:charm-tracing
+$ juju integrate tempo:tracing traefik:workload-tracing
+$ juju integrate tempo:tracing loki:charm-tracing
+$ juju integrate tempo:tracing loki:workload-tracing
+$ juju integrate tempo:tracing grafana:charm-tracing
+$ juju integrate tempo:tracing grafana:workload-tracing
+$ juju integrate tempo:tracing prometheus:charm-tracing
+$ juju integrate tempo:tracing prometheus:workload-tracing
 ```
 
 ```{note}


### PR DESCRIPTION
We now have new endpoints for tracing in most charms where it made sense to do the split.